### PR TITLE
Use `ENV.deparallelize` instead of `ENV.j1`

### DIFF
--- a/cmigemo-mk.rb
+++ b/cmigemo-mk.rb
@@ -16,7 +16,7 @@ class CmigemoMk < Formula
     cd 'dict' do
       system "make utf-8"
     end
-    ENV.j1 # Install can fail on multi-core machines unless serialized
+    ENV.deparallelize # Install can fail on multi-core machines unless serialized
     system "make osx-install"
   end
 end


### PR DESCRIPTION
I found the following error while installing `cmigemo-mk`.
I fixed `cmigemo-mk.rb`.

```
Error: Calling ENV.j1 is disabled!
Use ENV.deparallelize instead.
/usr/local/Homebrew/Library/Taps/splhack/homebrew-splhack/cmigemo-mk.rb:19:in `install'
Please report this to the splhack/splhack tap!
Or, even better, submit a PR to fix it!
```